### PR TITLE
Fix restore_copied path handling

### DIFF
--- a/kraken-pipeline.py
+++ b/kraken-pipeline.py
@@ -147,7 +147,10 @@ def process_csvs(input_path, parquet_path, delete_csv, logger):
 def restore_copied(input_path, logger):
     count = 0
     for f in input_path.rglob("*.csv.copied"):
-        original = f.with_suffix(".csv")
+        # Path.with_suffix() only replaces the last extension, so using it
+        # directly on "file.csv.copied" would result in "file.csv.csv".
+        # Instead remove the trailing ".copied" extension entirely.
+        original = f.with_suffix("")
         f.rename(original)
         count += 1
     logger.info("Restored %d files.", count)


### PR DESCRIPTION
## Summary
- ensure `.csv.copied` files restore correctly in `kraken-pipeline.py`

## Testing
- `python -m py_compile csv_to_parquet.py download_kraken.py kraken-pipeline.py`
- *(failed: ModuleNotFoundError: No module named 'requests' when running `kraken-pipeline.py`)*

------
https://chatgpt.com/codex/tasks/task_e_6840a9f331f4832d9daa9191d83856c9